### PR TITLE
Fix: Typo in GraphQL and Node.js post

### DIFF
--- a/content/posts/getting-started-with-graphql-and-nodejs/index.md
+++ b/content/posts/getting-started-with-graphql-and-nodejs/index.md
@@ -82,7 +82,7 @@ type Song {
 
 type Author {
   name: String
-  song: [Song]
+  songs: [Song]
 }
 ```
 


### PR DESCRIPTION
## Fix: Typo in GraphQL and Node.js post

A typo in the schema example